### PR TITLE
Add rigid filter to box resize

### DIFF
--- a/polyellipsoid/ellipsoid.py
+++ b/polyellipsoid/ellipsoid.py
@@ -20,5 +20,3 @@ class Ellipsoid(Compound):
         )
         self.add([self.head, self.tail])
         self.add_bond([self.head, self.tail])
-
-   

--- a/polyellipsoid/ellipsoid.py
+++ b/polyellipsoid/ellipsoid.py
@@ -19,3 +19,6 @@ class Ellipsoid(Compound):
                 mass=mass/2
         )
         self.add([self.head, self.tail])
+        self.add_bond([self.head, self.tail])
+
+   

--- a/polyellipsoid/simulate.py
+++ b/polyellipsoid/simulate.py
@@ -107,8 +107,9 @@ class Simulation:
         self.integrator = hoomd.md.Integrator(
                 dt=dt, integrate_rotational_dof=True
         )
-        self.integrator.forces = [gb, harmonic_bond]
         self.integrator.rigid = self.rigid
+        self.integrator.forces = [gb, harmonic_bond]
+        
         # Set up gsd and log writers
         gsd_writer, table_file = self._hoomd_writers(
                 group=self.all, forcefields=[gb, harmonic_bond]
@@ -143,7 +144,8 @@ class Simulation:
                 box1=self.sim.state.box,
                 box2=self.target_box,
                 variant=ramp,
-                trigger=box_resize_trigger
+                trigger=box_resize_trigger,
+                filter=self.all
         )
         self.sim.operations.updaters.append(box_resize)
 


### PR DESCRIPTION
Changes:

1- Set rigid particle filter to `hoomd.update.BoxResize` in shrink function.

2- Add bond between head and tail particle in Ellipsoid compound.