### PR TITLE
Add Angles

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - freud
+  - gmso
   - gsd
   - hoomd=*=*cpu*
   - mbuild

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - freud
+  - gmso
   - gsd
   - hoomd=*=*gpu*
   - mbuild

--- a/polyellipsoid/ellipsoid.py
+++ b/polyellipsoid/ellipsoid.py
@@ -18,5 +18,16 @@ class Ellipsoid(Compound):
                 name="CT",
                 mass=mass/2
         )
+        self.mid_head = Compound(
+                pos=[0,0,self.length/4]
+                name="CHM"
+                mass=0
+        )
+        self.mid_tail = Compound(
+                pos=[0,0,-self.length/4]
+                name="CTM"
+                mass=0
+        )
         self.add([self.head, self.tail])
-        self.add_bond([self.head, self.tail])
+        self.add_bond([self.head, self.mid_head])
+        self.add_bond([self.tail, self.mid_tail])

--- a/polyellipsoid/ellipsoid.py
+++ b/polyellipsoid/ellipsoid.py
@@ -2,32 +2,19 @@ from mbuild import Compound
 
 
 class Ellipsoid(Compound):
-    def __init__(
-            self, mass, length, name="dimer"
-    ):
+    def __init__(self, mass, length, name="dimer"):
         super(Ellipsoid, self).__init__(name=name)
         self.length = float(length)
         # Create the constituent particles
         self.head = Compound(
                 pos=[0, 0, self.length/2],
                 name="CH",
-                mass=mass/2
+                mass=mass/4
         )
         self.tail = Compound(
                 pos=[0, 0, -self.length/2],
                 name="CT",
-                mass=mass/2
-        )
-        self.mid_head = Compound(
-                pos=[0,0,self.length/4]
-                name="CHM"
-                mass=0
-        )
-        self.mid_tail = Compound(
-                pos=[0,0,-self.length/4]
-                name="CTM"
-                mass=0
+                mass=mass/4
         )
         self.add([self.head, self.tail])
-        self.add_bond([self.head, self.mid_head])
-        self.add_bond([self.tail, self.mid_tail])
+        self.add_bond([self.head, self.tail])

--- a/polyellipsoid/simulate.py
+++ b/polyellipsoid/simulate.py
@@ -73,7 +73,7 @@ class Simulation:
         gmso_system.identify_connections()
         parmed_system = to_parmed(gmso_system)
         # Atom types need to be set for angles to be correctly added
-        for atom in self.parmed_system.atoms:
+        for atom in parmed_system.atoms:
             atom.type = atom.name
 
         self._snapshot, refs = to_hoomdsnapshot(

--- a/polyellipsoid/tests/test_ellipsoid.py
+++ b/polyellipsoid/tests/test_ellipsoid.py
@@ -9,5 +9,5 @@ class TestEllipsoid(BaseTest):
     def test_make_ellipsoid(self):
         bead = Ellipsoid(name="A", mass=100, length=2.0)
         assert [p.name for p in bead.particles()] == ["CH", "CT"]
-        assert np.array_equal(bead[0].xyz[0], np.array([1.0, 0, 0]))
-        assert np.array_equal(bead[1].xyz[0], np.array([-1.0, 0, 0]))
+        assert np.array_equal(bead[0].xyz[0], np.array([0.0, 0, 1.0]))
+        assert np.array_equal(bead[1].xyz[0], np.array([0.0, 0, -1.0]))

--- a/polyellipsoid/tests/test_simulate.py
+++ b/polyellipsoid/tests/test_simulate.py
@@ -6,6 +6,24 @@ import pytest
 
 class TestSimulate(BaseTest):
 
+    def test_angles(self, packed_system):
+        sim = Simulation(
+                system=packed_system,
+                lperp=1.0,
+                lpar=1.0,
+                epsilon=1.0,
+                tau=0.1,
+                dt=0.001,
+                r_cut=2.0,
+                bond_k=1000,
+                angle_k=200,
+                angle_theta=2.0,
+                seed=42,
+                gsd_write=1000,
+                log_write=100
+        )
+        sim.quench(n_steps=2000, kT=2.0)
+
     def test_init_sim(self, packed_system):
         sim = Simulation(
                 system=packed_system,

--- a/polyellipsoid/tests/test_system.py
+++ b/polyellipsoid/tests/test_system.py
@@ -44,8 +44,8 @@ class TestSystem(BaseTest):
                 bead_length=2,
                 bond_length=0.2
         )
-        assert len(sys.chains) == 2
-        assert len(packed_system.chains) == 1
+        assert len(sys.chains) == 10 
+        assert sys.n_beads == 45
 
 
     def test_pack(self):


### PR DESCRIPTION
This PR adds the ability to include a harmonic angle potential between neighboring beads.  This requires using the `identify_connections()` function from gmso to ensure the angle groups and types are added to the hoomd snapshot. 