### PR TITLE
Make it easier to choose and switch between integrator methods

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -2,11 +2,11 @@ name: polyellipsoid
 channels:
   - conda-forge
 dependencies:
+  - mbuild>=0.15
   - freud
   - gmso
   - gsd
   - hoomd=*=*cpu*
-  - mbuild
   - numpy
   - pip
   - pytest

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -2,15 +2,16 @@ name: polyellipsoid
 channels:
   - conda-forge
 dependencies:
+  - mbuild>=0.15
   - freud
   - gmso
   - gsd
   - hoomd=*=*gpu*
-  - mbuild
   - numpy
   - pip
   - pytest
   - pytest-cov
   - python
   - pip:
-    - git+https://github.com/cmelab/cmeutils.git@master
+      - git+https://github.com/cmelab/cmeutils.git@master
+

--- a/polyellipsoid/tests/base_test.py
+++ b/polyellipsoid/tests/base_test.py
@@ -28,7 +28,6 @@ class BaseTest:
                 lperp=0.5,
                 lpar=1.0,
                 epsilon=5,
-                tau=0.01,
                 dt=0.001,
                 r_cut=2.5,
                 bond_k=100000,

--- a/polyellipsoid/tests/test_simulate.py
+++ b/polyellipsoid/tests/test_simulate.py
@@ -6,6 +6,22 @@ import numpy as np
 import pytest
 
 class TestSimulate(BaseTest):
+    def test_change_dt(self, packed_system):
+        sim = Simulation(
+                system=packed_system,
+                lperp=1.0,
+                lpar=1.0,
+                epsilon=1.0,
+                dt=0.001,
+                r_cut=2.0,
+                bond_k=1000,
+                seed=42,
+                gsd_write=1000,
+                log_write=100
+        )
+        assert sim.dt == 0.001
+        sim.dt = 0.0001
+        assert sim.dt == 0.0001
 
     def test_angles(self, packed_system):
         sim = Simulation(
@@ -52,7 +68,7 @@ class TestSimulate(BaseTest):
     def test_run_NVT(self, sim_init):
         sim_init.run_NVT(n_steps=2000, kT=1.0, tau_kt=0.01) 
         assert isinstance(sim_init.method, hoomd.md.methods.NVT)
-        
+
     def test_run_NPT(self, sim_init):
         sim_init.run_NPT(
                 n_steps=0, kT=1.0, tau_kt=0.01, pressure=0.001, tau_pressure=0.1
@@ -81,12 +97,6 @@ class TestSimulate(BaseTest):
         )
         sim_init.run_NVT(n_steps=2000, kT=kT_ramp, tau_kt=0.001)
 
-    @pytest.mark.skip(reason="Getting particle out of box errors")
     def test_shrink_to_quench(self, sim_init):
-        sim_init.shrink(n_steps=2000, kT=1.0)
-        sim_init.quench(n_steps=2000, kT=2.0)
-
-    @pytest.mark.skip(reason="Getting particle out of box errors")
-    def test_shrink_to_anneal(self, sim_init):
-        sim_init.shrink(n_steps=2000, kT=1.0)
-        sim_init.anneal(kT_init=1.0, kT_final=2.0, step_sequence=[200]*5)
+        sim_init.run_shrink(n_steps=2000, kT=1.0, tau_kt=0.001)
+        sim_init.run_NVT(n_steps=2000, kT=2.0, tau_kt=0.001)

--- a/polyellipsoid/tests/test_simulate.py
+++ b/polyellipsoid/tests/test_simulate.py
@@ -1,6 +1,7 @@
 from polyellipsoid import Simulation
 from base_test import BaseTest
 
+import hoomd
 import numpy as np
 import pytest
 
@@ -12,7 +13,6 @@ class TestSimulate(BaseTest):
                 lperp=1.0,
                 lpar=1.0,
                 epsilon=1.0,
-                tau=0.1,
                 dt=0.001,
                 r_cut=2.0,
                 bond_k=1000,
@@ -23,7 +23,7 @@ class TestSimulate(BaseTest):
                 log_write=100
         )
         assert sim.snapshot.angles.types[0] == "B-B-B"
-        sim.quench(n_steps=2000, kT=2.0)
+        sim.run_NVT(n_steps=2000, kT=2.0, tau_kt=0.001)
 
     def test_init_sim(self, packed_system):
         sim = Simulation(
@@ -31,7 +31,6 @@ class TestSimulate(BaseTest):
                 lperp=1.0,
                 lpar=1.0,
                 epsilon=1.0,
-                tau=0.1,
                 dt=0.001,
                 r_cut=2.0,
                 bond_k=1000,
@@ -41,19 +40,46 @@ class TestSimulate(BaseTest):
         )
         ids = sim.snapshot.particles.typeid
         num_rigid = np.count_nonzero(ids==0)
+        assert sim.dt == 0.001
         assert num_rigid == 100
 
         for i in range(0, num_rigid):
             assert sim.snapshot.particles.types[ids[i]] == "R"
     
     def test_shrink(self, sim_init):
-        sim_init.shrink(n_steps=2000, kT=1.0) 
+        sim_init.run_shrink(n_steps=2000, kT=1.0, tau_kt=0.01) 
         
-    def test_quench(self, sim_init):
-        sim_init.quench(n_steps=2000, kT=1.0) 
+    def test_run_NVT(self, sim_init):
+        sim_init.run_NVT(n_steps=2000, kT=1.0, tau_kt=0.01) 
+        assert isinstance(sim_init.method, hoomd.md.methods.NVT)
         
-    def test_anneal(self, sim_init):
-        sim_init.anneal(kT_init=1.0, kT_final=2.0, step_sequence=[200]*5)
+    def test_run_NPT(self, sim_init):
+        sim_init.run_NPT(
+                n_steps=0, kT=1.0, tau_kt=0.01, pressure=0.001, tau_pressure=0.1
+        ) 
+        assert isinstance(sim_init.method, hoomd.md.methods.NPT)
+
+    def test_run_NVE(self, sim_init):
+        sim_init.run_NVE(n_steps=2000) 
+        assert isinstance(sim_init.method, hoomd.md.methods.NVE)
+
+    def test_update_method(self, sim_init):
+        sim_init.run_NVT(n_steps=0, kT=1.0, tau_kt=0.01)
+        assert isinstance(sim_init.method, hoomd.md.methods.NVT)
+        sim_init.run_NPT(
+                n_steps=0, kT=1.0, tau_kt=0.01, pressure=0.001, tau_pressure=0.1
+        )
+        assert isinstance(sim_init.method, hoomd.md.methods.NPT)
+        sim_init.run_NVE(n_steps=0)
+        assert isinstance(sim_init.method, hoomd.md.methods.NVE)
+        sim_init.run_langevin(n_steps=0, kT=1.0, alpha=0.5)
+        assert isinstance(sim_init.method, hoomd.md.methods.Langevin)
+
+    def test_temperature_ramp(self, sim_init):
+        kT_ramp = sim_init.temperature_ramp(
+                n_steps=2000, kT_start=0.5, kT_final=1.0, period=100
+        )
+        sim_init.run_NVT(n_steps=2000, kT=kT_ramp, tau_kt=0.001)
 
     @pytest.mark.skip(reason="Getting particle out of box errors")
     def test_shrink_to_quench(self, sim_init):


### PR DESCRIPTION
This PR introduces a pretty big API change to the `Simulation` class. It makes it much easier to run different integrator methods, switch between them, and change simulation properties and schemes between runs. I'll add an example soon.

